### PR TITLE
Add init scripts for jackd and pd. 

### DIFF
--- a/asteriskserver/baseinstall_playbook.yml
+++ b/asteriskserver/baseinstall_playbook.yml
@@ -6,6 +6,8 @@
     - include: users.yml
     - include: config.yml
     - include: install_misc.yml
+    - include: install_jackd.yml
+    - include: install_pd.yml
     - include: install_asterisk.yml
     - include: install_asterisk_helpers.yml version={{ conf_version }}
     - include: update_asterisk.yml version={{ conf_version }}

--- a/asteriskserver/install_jackd.yml
+++ b/asteriskserver/install_jackd.yml
@@ -1,0 +1,31 @@
+---
+- name: unpack jack
+  unarchive:
+    src: src/jack-1.9.10.tar.bz2
+    dest: /tmp
+- name: configure jack
+  command: ./waf configure --alsa
+  args:
+    chdir: /tmp/jack-1.9.10
+- name: make jack
+  command: ./waf build
+  args:
+    chdir: /tmp/jack-1.9.10
+- name: install jack
+  command: ./waf install
+  args:
+    chdir: /tmp/jack-1.9.10
+- name: install init script
+  copy:
+    src: src/jackd-init-script
+    dest: /etc/init.d/jackd
+    owner: root
+    group: root
+    mode: 0755
+- name: symlink init script for startup
+  file:
+    src: /etc/init.d/jackd
+    dest: /etc/rc3.d/S91jackd
+    owner: root
+    group: root
+    state: link

--- a/asteriskserver/install_misc.yml
+++ b/asteriskserver/install_misc.yml
@@ -29,42 +29,6 @@
   command: make install
   args:
     chdir: /tmp/mpg123-1.22.2
-- name: unpack jack
-  unarchive:
-    src: src/jack-1.9.10.tar.bz2
-    dest: /tmp
-- name: configure jack
-  command: ./waf configure --alsa
-  args:
-    chdir: /tmp/jack-1.9.10
-- name: make jack
-  command: ./waf build
-  args:
-    chdir: /tmp/jack-1.9.10
-- name: install jack
-  command: ./waf install
-  args:
-    chdir: /tmp/jack-1.9.10
-- name: unpack pd
-  unarchive:
-    src: src/pd-0.47-0.src.tar.gz
-    dest: /tmp
-- name: configure pd
-  command: sh autogen.sh
-  args:
-    chdir: /tmp/pd-0.47-0
-- name: configure pd
-  command: ./configure --enable-jack
-  args:
-    chdir: /tmp/pd-0.47-0
-- name: make pd
-  command: make
-  args:
-    chdir: /tmp/pd-0.47-0
-- name: install pd
-  command: make install
-  args:
-    chdir: /tmp/pd-0.47-0
 # XXX need a real daemon or supervisord, this doesn't restart
 # XXX festival server is not exactly safe
 - name: add festival to rc.local
@@ -78,4 +42,3 @@
     create: yes
 - name: run ldconfig on updated ld.so.conf
   command: /sbin/ldconfig
-  

--- a/asteriskserver/install_pd.yml
+++ b/asteriskserver/install_pd.yml
@@ -1,0 +1,34 @@
+- name: unpack pd
+  unarchive:
+    src: src/pd-0.47-0.src.tar.gz
+    dest: /tmp
+- name: configure pd
+  command: sh autogen.sh
+  args:
+    chdir: /tmp/pd-0.47-0
+- name: configure pd
+  command: ./configure --enable-jack
+  args:
+    chdir: /tmp/pd-0.47-0
+- name: make pd
+  command: make
+  args:
+    chdir: /tmp/pd-0.47-0
+- name: install pd
+  command: make install
+  args:
+    chdir: /tmp/pd-0.47-0
+- name: install init script
+  copy:
+    src: src/pd-init-script
+    dest: /etc/init.d/pd
+    owner: root
+    group: root
+    mode: 0755
+- name: symlink init script for startup
+  file:
+    src: /etc/init.d/pd
+    dest: /etc/rc3.d/S92pd
+    owner: root
+    group: root
+    state: link

--- a/asteriskserver/src/jackd-init-script
+++ b/asteriskserver/src/jackd-init-script
@@ -1,0 +1,66 @@
+#!/bin/bash
+# jackd         Init script for jack daemon
+#
+# Author:       futel
+#
+# description:  starts jackd
+# processname:  jackd
+
+PATH=/usr/bin:/sbin:/bin:/usr/sbin
+export PATH
+
+USER=asterisk
+
+# sudo -u asterisk /usr/local/bin/jackd
+JACKD_OPTS="-R -d dummy -r 16000"
+JACKD=/usr/local/bin/jackd
+RETVAL=0
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+start() {
+    echo -n $"Starting jackd..."
+    daemon --user ${USER} --pidfile /var/run/jackd.pid "sh -c '${JACKD} ${JACKD_OPTS} > /dev/null &2>1'"
+    RETVAL=$?
+    echo
+    return ${RETVAL}
+}
+
+stop() {
+    echo -n $"Stopping jackd..."
+    killproc ${JACKD}
+    RETVAL=$?
+    echo jackd stopped
+    return ${RETVAL}
+}
+
+restart() {
+    stop
+    start
+}
+
+case "$1" in
+    start)
+        start
+    ;;
+    stop)
+        stop
+    ;;
+    restart)
+        restart
+    ;;
+    status)
+        PID=`pgrep -U ${USER} jackd`
+        if [ "" == "${PID}" ] ; then
+            echo jackd is not running
+        else
+            echo "jackd is running, pid = ${PID}"
+        fi
+    ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart|}"
+        exit 1
+esac
+
+exit $RETVAL

--- a/asteriskserver/src/pd-init-script
+++ b/asteriskserver/src/pd-init-script
@@ -1,0 +1,70 @@
+#!/bin/bash
+# pd         Init script for pd
+#
+# Author:       futel
+#
+# description:  starts pd
+# processname:  pd
+
+PATH=/usr/bin:/sbin:/bin:/usr/sbin
+export PATH
+
+USER=asterisk
+
+PD_OPTS="-nogui -rt -jack -channels 1 /vagrant/src/pd/startup.pd"
+PD=/usr/local/bin/pd
+RETVAL=0
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+start() {
+    EPID=`pgrep -u ${USER} pd`
+    if [ "" != "${EPID}" ] ; then
+        echo Pd is already running
+        exit 1
+    fi
+    echo -n $"Starting pd..."
+    daemon --user ${USER} --pidfile /var/run/pd.pid "sh -c '${PD} ${PD_OPTS} > /dev/null &2>1'"
+    RETVAL=$?
+    echo
+    return ${RETVAL}
+}
+
+stop() {
+    echo -n $"Stopping pd..."
+    killproc ${PD}
+    RETVAL=$?
+    echo pd stopped
+    return ${RETVAL}
+}
+
+restart() {
+    stop
+    start
+}
+
+case "$1" in
+    start)
+        start
+    ;;
+    stop)
+        stop
+    ;;
+    restart)
+        restart
+    ;;
+    status)
+        PID=`pgrep -U ${USER} pd`
+        if [ "" == "${PID}" ] ; then
+            echo pd is not running
+        else
+            echo "pd is running, pid = ${PID}"
+        fi
+    ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart|}"
+        exit 1
+esac
+
+exit $RETVAL


### PR DESCRIPTION
Set them up to be installed during provisioning.

There's room for improvement, and the startup pd file doesn't exist yet...and there's still the jack realtime issue, but its a start.