### PR TITLE
specify wav filetype, don't re-encode as mp3

### DIFF
--- a/asteriskserver/scripts/update_audio_assets.rb
+++ b/asteriskserver/scripts/update_audio_assets.rb
@@ -10,6 +10,7 @@ require 'find'
 require 'fileutils'
 require 'sndfile'
 
+OUTPUT_MP3 = false #make true if we want to re-encode mp3s as mp3 for the output
 SOX_COMPAND = "compand 0.14,1 6:-70,-24,-4.8 -8 -90 0.2"
 
 SRC_DIR = ARGV[1]
@@ -17,7 +18,7 @@ DEST_DIR = ARGV[0]
 
 puts "updating #{DEST_DIR} with audio from #{SRC_DIR}"
 
-sln_ext = {
+SLN_EXT = {
   8_000 => "sln",
   12_000 => "sln12",
   16_000 => "sln16",
@@ -29,9 +30,15 @@ sln_ext = {
   192_000 =>"sln192"
 }
 
-known_ext = sln_ext.values + ["mp3", "gsm"]
+known_ext = SLN_EXT.values + ["mp3", "gsm"]
 
 script_mtime = File.mtime(__FILE__)
+
+def get_extension(info) 
+  out_ext = SLN_EXT[info.samplerate]
+  raise "#{src} has an unsuppored sampling rate of #{info.samplerate}" unless out_ext
+  return out_ext
+end
 
 Find.find(SRC_DIR).each do |f|
   is_raw = false
@@ -46,63 +53,60 @@ Find.find(SRC_DIR).each do |f|
   dst = File.join(DEST_DIR, f)
   base = File.join(File.dirname(dst), File.basename(dst, ".*"))
 
+  #make the dir
+  FileUtils.mkdir_p(File.dirname(dst))
 
-  #simply copy mp3, if the source is newer
+  #convert mp3 to wav and use the info for the destination
   if src_ext == ".mp3"
-    out_ext = "mp3"
-  else
-    info = Sndfile::File.info(src)    
-    out_ext = sln_ext[info.samplerate]
+    if OUTPUT_MP3
+      out_ext = 'mp3'
+    else
+      wav = base + "-tmp.wav"
+      raise "MP3 cannot create tmp wav from #{out_ext}" unless system("sox", src, wav)
+      cleanup << wav
+      src = wav
+    end
+  end
+
+  unless OUTPUT_MP3 and src_ext == ".mp3"
+    info = Sndfile::File.info(src)
+    out_ext = get_extension(info)
     is_raw = true
-    raise "#{src} has an unsuppored sampling rate of #{info.samplerate}" unless out_ext
   end
 
   dst = base + "." + out_ext
   #ditch if the file exists and the dest is newer
   next if File.exist?(dst) and File.mtime(dst) > File.mtime(src) and File.mtime(dst) > script_mtime
 
-  #make the dir
-  FileUtils.mkdir_p(File.dirname(dst))
 
   #report
   puts "#{src} -> #{dst}"
 
-  #convert to wav
-  wav = base + "-tmp.wav"
-  raise "cannot create tmp wav from #{out_ext}" unless system("sox", src, wav)
-  cleanup << wav
-  src = wav
+  #convert to wav if we haven't already
+  if wav.nil?
+    wav = base + "-tmp.wav"
+    raise "cannot create tmp wav from #{out_ext}" unless system("sox", src, wav)
+    cleanup << wav
+    src = wav
+    info = Sndfile::File.info(src)    
+  end
 
-  if src_ext != ".mp3"  
-    #make mono
-    if info.channels != 1
-      mono = base + "-tmp-mono.wav"
-      raise "failed to make a mono file of #{src}" unless system("sndfile-mix-to-mono", src, mono)
-      cleanup << mono
-      src = mono
-    end
+  #make mono
+  if info.channels != 1
+    mono = base + "-tmp-mono.wav"
+    raise "failed to make a mono file of #{src}" unless system("sndfile-mix-to-mono", src, mono)
+    cleanup << mono
+    src = mono
   end
 
   #compress
   compressed = base + "-tmp-compressed.wav"
-  raise "failed to apply dynamic range compression" unless system("sox #{src} #{compressed} #{SOX_COMPAND}")
+  raise "failed to apply dynamic range compression" unless system("sox #{src} -b 16 -c 1 #{compressed} #{SOX_COMPAND}")
   cleanup << compressed
   src = compressed
 
-  #convert back to mp3
-  if src_ext == ".mp3"  
-    mp3 = base + "-tmp-mp3.mp3"
-    raise "failed to encode to mp3" unless system("lame", "--quiet", src, mp3)
-    src = mp3
-    cleanup << mp3
-  end
-
-  #copy then normalize
-  normalized = base + "-tmp-norm." + out_ext
-  cleanup << normalized
-  FileUtils.copy(src, normalized) #normalize happens in place, so copy the file first
-  raise "failed to normalize" unless system("normalize-audio", "--quiet", "--peak", normalized)
-  src = normalized
+  #normalize the wav
+  raise "failed to normalize" unless system("normalize-audio", "--quiet", "--peak", src)
 
   #remove header if it is raw
   if is_raw
@@ -110,6 +114,13 @@ Find.find(SRC_DIR).each do |f|
     raise "cannot create raw encoding" unless system("sndfile-convert", "-pcm16", src, raw)
     cleanup << raw
     src = raw
+  elsif out_ext == ".mp3" and OUTPUT_MP3 #convert back to mp3
+    mp3 = base + "-tmp-mp3.mp3"
+    raise "failed to encode to mp3" unless system("lame", "--quiet", src, mp3)
+    src = mp3
+    cleanup << mp3
+  else
+    raise "don't know what to do with #{src} -> #{dst}"
   end
 
   #copy to the final location


### PR DESCRIPTION
I disabled re-encoding to mp3...
it does make a 2nd run slower because mp3s have to be converted to wav to know what sampling rate and therefore what suffix they'll have.
I also specified the wav file format for sox output.. seems to have resolved the error on my system.
BTW, you'll have to have `lame` if you want to re-enable mp3 encoding.

let me know how this works for you.