### PR TITLE
guard user input to be numeric before int()

### DIFF
--- a/asteriskserver/src/var/lib/asterisk/agi-bin/progged.py
+++ b/asteriskserver/src/var/lib/asterisk/agi-bin/progged.py
@@ -55,7 +55,8 @@ def progged(agi_o):
         util.say(agi_o, "you-win", preferred_subs=['challenge'], escape=True)
         return 0
     move = play_list_and_get_input(agi_o, files_to_play)
-    game_state = update_game_state(game_state, MOVES[int(move)-1])
+    if move in set('0123456789'):
+        game_state = update_game_state(game_state, MOVES[int(move)-1])
 
 def create_game_state(field_size):
   def rand():


### PR DESCRIPTION
This fixes #342 
The result is that hitting a non-numeric key will just keep the game state the same and repeat the prompt, which I think is acceptable. 