### PR TITLE
dont return agio result

### DIFF
--- a/asteriskserver/src/var/lib/asterisk/agi-bin/konami.py
+++ b/asteriskserver/src/var/lib/asterisk/agi-bin/konami.py
@@ -51,7 +51,7 @@ class Konami:
     def _say(self, file):
         path = util.sound_path(file, ['challenge'])
         if path:
-            return self.agi_o.stream_file(path, escape_digits='0123456789*#ABCD')
+            satan = self.agi_o.stream_file(path, escape_digits='0123456789*#ABCD')
 
 
 def konami(agi_o):


### PR DESCRIPTION
@lboom and I were doing some troubleshooting and he discovered that returning the value from the agio call actually causes the thing to fail in strange ways.  So, screw that, just play the sound.  If they hit a key while it's playing it's just ignored.  I guess that's better than trying to account for whatever random thing is returned.  