### PR TITLE
Audio quality tweaks

### DIFF
--- a/asteriskserver/scripts/update_audio_assets.rb
+++ b/asteriskserver/scripts/update_audio_assets.rb
@@ -11,7 +11,7 @@ require 'fileutils'
 require 'sndfile'
 
 OUTPUT_MP3 = false #make true if we want to re-encode mp3s as mp3 for the output
-SOX_COMPAND = "compand 0.14,1 6:-70,-24,-4.8 -8 -90 0.2"
+SOX_COMPAND = "compand 0.001,0.3 6:-30,-3 -6 -12 0.002"
 
 SRC_DIR = ARGV[1]
 DEST_DIR = ARGV[0]

--- a/asteriskserver/scripts/update_audio_assets.rb
+++ b/asteriskserver/scripts/update_audio_assets.rb
@@ -18,31 +18,12 @@ DEST_DIR = ARGV[0]
 
 puts "updating #{DEST_DIR} with audio from #{SRC_DIR}"
 
-SLN_EXT = {
-  8_000 => "sln",
-  12_000 => "sln12",
-  16_000 => "sln16",
-  22_050 => "sln16",            # XXX will this just sound bad?
-  24_000 => "sln24",
-  32_000 => "sln32",
-  44_100 => "sln44",
-  48_000 => "sln48",
-  96_000 => "sln96",
-  192_000 =>"sln192"
-}
-
-known_ext = SLN_EXT.values + ["mp3", "gsm"]
-
 script_mtime = File.mtime(__FILE__)
 
-def get_extension(info) 
-  out_ext = SLN_EXT[info.samplerate]
-  raise "#{src} has an unsuppored sampling rate of #{info.samplerate}" unless out_ext
-  return out_ext
-end
-
 Find.find(SRC_DIR).each do |f|
-  is_raw = false
+  is_raw = true
+  out_ext = 'sln'
+
   cleanup = []
   next if File.directory?(f)
 
@@ -61,18 +42,8 @@ Find.find(SRC_DIR).each do |f|
   if src_ext == ".mp3"
     if OUTPUT_MP3
       out_ext = 'mp3'
-    else
-      wav = base + "-tmp.wav"
-      raise "MP3 cannot create tmp wav from #{out_ext}" unless system("sox", src, wav)
-      cleanup << wav
-      src = wav
+      is_raw = false
     end
-  end
-
-  unless OUTPUT_MP3 and src_ext == ".mp3"
-    info = Sndfile::File.info(src)
-    out_ext = get_extension(info)
-    is_raw = true
   end
 
   dst = base + "." + out_ext


### PR DESCRIPTION
Hopefully an improvement. Dynamic range compression should prevent most, if not all clipping, and make it easier to hear the audio through a phone in a noisy environment. Bandpass filtering will remove inaudible energy that could foul up dynamic range compression and harm intelligibility. All output files are 8kHz. 8kHz should be enough for anybody. I also tested on one of the Wildcard Line .mp3s, to make sure I hadn't regressed the MP3 path in this code, and it seems OK.