### PR TITLE
use symlinks for sounds on vbox

### DIFF
--- a/asteriskserver/deploy/update_asterisk_playbook.yml
+++ b/asteriskserver/deploy/update_asterisk_playbook.yml
@@ -14,4 +14,4 @@
   become: true
   tasks:
     - include: update_asterisk.yml
-    - include: update_asterisk_sounds.yml    
+    - include: update_asterisk_sounds_virtualbox.yml

--- a/asteriskserver/deploy/update_asterisk_sounds_virtualbox.yml
+++ b/asteriskserver/deploy/update_asterisk_sounds_virtualbox.yml
@@ -1,0 +1,48 @@
+---
+- name: link es statements
+  file:
+    src: /vagrant/src/var/lib/asterisk/sounds/es
+    dest: /opt/asterisk/var/lib/asterisk/sounds/es
+    state: link
+- name: link en futelconf
+  file:
+    src: /vagrant/src/var/lib/asterisk/sounds/en/futelconf
+    dest: /opt/asterisk/var/lib/asterisk/sounds/en/futelconf
+    state: link
+- name: link en statements
+  file:
+    src: /vagrant/src/var/lib/asterisk/sounds/en/statements
+    dest: /opt/asterisk/var/lib/asterisk/sounds/en/statements
+    state: link
+- name: link futel sounds
+  file:
+    src: /vagrant/src/var/lib/asterisk/sounds/futel
+    dest: /opt/asterisk/var/lib/asterisk/sounds/futel
+    state: link
+- name: asterisk hold music link
+  file:
+    src: /vagrant/src/var/lib/asterisk/moh/hold
+    dest: /opt/asterisk/var/lib/asterisk/moh/hold
+    owner: asterisk
+    group: asterisk
+    state: link
+- name: operator hold music link
+  file:
+    src: /vagrant/src/var/lib/asterisk/moh/operator
+    dest: /opt/asterisk/var/lib/asterisk/moh/operator
+    owner: asterisk
+    group: asterisk
+    state: link
+- name: midi hold music link
+  file:
+    src: /vagrant/src/var/lib/asterisk/moh/midi
+    dest: /opt/asterisk/var/lib/asterisk/moh/midi
+    owner: asterisk
+    group: asterisk
+    state: link
+- name: make recordings directory                                        
+  file:                                                                  
+    path: /opt/asterisk/var/lib/asterisk/sounds/futel/recordings         
+    state: directory                                                     
+    owner: asterisk                                                      
+    group: asterisk


### PR DESCRIPTION
speed up dev time for virtualbox. this is a decent step toward reduced pain when running things like:
`vagrant provision --provision-with update_asterisk`