### PR TITLE
add timestamp to sns events

### DIFF
--- a/asteriskserver/src/eventlistener.py
+++ b/asteriskserver/src/eventlistener.py
@@ -11,6 +11,7 @@ import socket
 import json
 import logging
 import sys
+from datetime import datetime, timezone
 
 import boto3
 from asterisk import manager
@@ -28,8 +29,10 @@ logging.basicConfig(
     format='%(asctime)s %(message)s')
 
 def event_to_message(event):
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     return json.dumps(
-        {'hostname': socket.gethostname(),
+        {'timestamp': now,
+         'hostname': socket.gethostname(),
          'event': event.headers})
 
 def handle_interesting_event(event, manager, snsclient):


### PR DESCRIPTION
Asterisk events aren't being surfaced with timestamps, and consumers then have to rely on the timestamp of the published queue transport events.

Instead of relying on the message time, we can instead embed the time into the event too. This allows us to later backfill from files without having to rely on time of message publication.