### PR TITLE
Add 3 support services to pdx menu

### DIFF
--- a/src/etc/asterisk/extensions.conf
+++ b/src/etc/asterisk/extensions.conf
@@ -289,4 +289,18 @@ same => n,Goto(dial,+18003779450,1)
 exten => s,1,Gosub(metric,s,1(shady-bbs))
 same => n,Goto(dial,+18134695930,1)
 
+[project-respond]
+; 24/7 crisis intervention https://cascadiahealth.org/services/crisis-intervention/
+exten => s,1,Gosub(metric,s,1(project-respond))
+same => n,Goto(dial,+5039884888,1)
+
+[oregon-youthline]
+; https://oregonyouthline.org/
+exten => s,1,Gosub(metric,s,1(oregon-youthline))
+same => n,Goto(dial,+8779688491,1)
+
+[portland-alcohol-and-drug-helpline]
+exten => s,1,Gosub(metric,s,1(portland-alcohol-and-drug-helpline))
+same => n,Goto(dial,+5032441312,1)
+
 #include extensions_secret.conf

--- a/src/etc/asterisk/extensions_directory.lua
+++ b/src/etc/asterisk/extensions_directory.lua
@@ -174,11 +174,13 @@ local extensions = {
          statement_dir="network"}),
     community_services_oregon = util.context(
         {menu_entries={
-             {"for-two-one-one-community-resources", "info-211"},
-             {"for-multnomah-county-mental-health-crisis-intervention",
-              "mental-health-crisis"},
-             {"for-the-call-to-safety-crisis-line", "call-to-safety"},
              {"for-the-suicide-prevention-hotline", "suicide-hotline"},
+             {"if-you-need-help-with-a-crisis-situation", "project-respond"},
+             {"if-you-are-a-teenager-needing-support", "oregon-youthline"},
+             {"for-two-one-one-community-resources", "info-211"},
+             {"for-multnomah-county-mental-health-crisis-intervention", "mental-health-crisis"},
+             {"for-the-call-to-safety-crisis-line", "call-to-safety"},
+             {"for-help-with-drugs-or-alcohol-problems", "portland-alcohol-and-drug-helpline"},
              {"for-an-obamaphone", "obamaphone-oregon"}},
          statement_dir="community-service"}),
     community_services_michigan = util.context(

--- a/src/var/lib/asterisk/agi-bin/statements.py
+++ b/src/var/lib/asterisk/agi-bin/statements.py
@@ -242,6 +242,9 @@ statement_groups = [
          'star']},
     {'name': 'community-service',
      'statements': [
+         'if-you-need-help-with-a-crisis-situation',
+         'if-you-are-a-teenager-needing-support',
+         'for-help-with-drugs-or-alcohol-problems',
          'for-two-one-one-community-resources',
          'for-multnomah-county-mental-health-crisis-intervention',
          'for-the-call-to-safety-crisis-line',


### PR DESCRIPTION
This helps with issue #420 but I think we should get the voice prompts in place first before committing to this?

I _think_ this changes the ordering of the pdx services menu somewhat, in a way that I hope is slightly more important, but happy to discuss/change.

Do we get text-to-speech if the voice files don't exist? I can't remember if it's automatic.